### PR TITLE
Allow compiling without JXL support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,20 @@ pkg_check_modules(
   hyprutils
   libjpeg
   libwebp
+  libmagic)
+
+pkg_check_modules(
+  JXL
   libjxl
   libjxl_cms
   libjxl_threads
-  libmagic)
+)
+if(NOT JXL_FOUND)
+  file(GLOB_RECURSE JPEGXLFILES CONFIGURE_DEPENDS "src/*JpegXL.cpp")
+  list(REMOVE_ITEM SRCFILES ${JPEGXLFILES})
+else()
+  add_compile_definitions(JXL_FOUND)
+endif()
 
 add_library(hyprgraphics SHARED ${SRCFILES})
 target_include_directories(
@@ -59,7 +69,7 @@ target_include_directories(
   PRIVATE "./src")
 set_target_properties(hyprgraphics PROPERTIES VERSION ${HYPRGRAPHICS_VERSION}
                                               SOVERSION 0)
-target_link_libraries(hyprgraphics PkgConfig::deps)
+target_link_libraries(hyprgraphics PkgConfig::deps ${JXL_LIBRARIES})
 
 # tests
 add_custom_target(tests)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Dep list:
  - hyprutils
  - libjpeg
  - libwebp
- - libjxl
- - libjxl_cms
- - libjxl_threads
+ - libjxl [optional]
+ - libjxl_cms [optional]
+ - libjxl_threads [optional]
  - libmagic
 
 ## Building

--- a/src/image/Image.cpp
+++ b/src/image/Image.cpp
@@ -1,7 +1,9 @@
 #include <hyprgraphics/image/Image.hpp>
 #include "formats/Bmp.hpp"
 #include "formats/Jpeg.hpp"
+#ifdef JXL_FOUND
 #include "formats/JpegXL.hpp"
+#endif
 #include "formats/Webp.hpp"
 #include <magic.h>
 #include <format>
@@ -27,8 +29,15 @@ Hyprgraphics::CImage::CImage(const std::string& path) : filepath(path) {
         CAIROSURFACE = WEBP::createSurfaceFromWEBP(path);
         mime = "image/webp";
     } else if (path.find(".jxl") == len - 4 || path.find(".JXL") == len - 4) {
+
+#ifdef JXL_FOUND
         CAIROSURFACE = JXL::createSurfaceFromJXL(path);
         mime = "image/jxl";
+#else
+        lastError = "hyprgraphics compiled without JXL support";
+        return;
+#endif
+
     } else {
         // magic is slow, so only use it when no recognized extension is found
         auto handle = magic_open(MAGIC_NONE | MAGIC_COMPRESS | MAGIC_SYMLINK);

--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -25,8 +25,11 @@ int main(int argc, char** argv, char** envp) {
     for (auto& file : std::filesystem::directory_iterator("./resource/images/")) {
         if (!file.is_regular_file())
             continue;
-
-        EXPECT(tryLoadImage(file.path()), true);
+        auto expectation = true;
+#ifndef JXL_FOUND
+        if (file.path().filename() == "hyprland.jxl") expectation = false;
+#endif
+        EXPECT(tryLoadImage(file.path()), expectation);
     }
 
     return ret;


### PR DESCRIPTION
In Alpine Linux, libjxl is not available under some architectures (due to failing tests). (Namely s390x -- So if anybody was running Hyprland on their IBM mainframe, they currently are not able to run version >0.46 because of hyprgraphics).

Ideally somebody would fix that (https://github.com/libjxl/libjxl/issues/3629). (LibJXL is a google project which requires signing their CLA, which I have no motivation to do).

I think hyprgraphics will still be a useful library without JpegXL support.