### PR TITLE
cmake: unbreak JXL build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ pkg_check_modules(
 
 pkg_check_modules(
   JXL
+  IMPORTED_TARGET
   libjxl
   libjxl_cms
   libjxl_threads
@@ -70,7 +71,10 @@ target_include_directories(
   PRIVATE "./src")
 set_target_properties(hyprgraphics PROPERTIES VERSION ${HYPRGRAPHICS_VERSION}
                                               SOVERSION 0)
-target_link_libraries(hyprgraphics PkgConfig::deps ${JXL_LIBRARIES})
+target_link_libraries(hyprgraphics PkgConfig::deps)
+if(JXL_FOUND)
+  target_link_libraries(hyprgraphics PkgConfig::JXL)
+endif()
 
 # tests
 add_custom_target(tests)


### PR DESCRIPTION
Regressed by #6. Affects [FreeBSD](https://wiki.freebsd.org/WarnerLosh/UsrLocal#Include_paths), other BSDs and maybe even Nix due to using different prefix for each package. To reproduce install libjxl outside of `/usr` and `/usr/local` thus not part of default C compiler search path.

```
$ pkg-config --libs libjxl
-L/libjxl_prefix/local/lib -ljxl

$ export PKG_CONFIG_PATH=/libjxl_prefix/lib/pkgconfig
$ cmake -G Ninja -B _build
$ cmake --build _build
[...]
ld: error: unable to find library -ljxl
ld: error: unable to find library -ljxl_cms
ld: error: unable to find library -ljxl_threads
c++: error: linker command failed with exit code 1 (use -v to see invocation)
```
