### PR TITLE
nix: use gcc15

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737469691,
-        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
         inputs.hyprutils.overlays.default
         (final: prev: {
           hyprgraphics = final.callPackage ./nix/default.nix {
-            stdenv = final.gcc14Stdenv;
+            stdenv = final.gcc15Stdenv;
             version = version + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
           };
           hyprgraphics-with-tests = final.hyprgraphics.override {doCheck = true;};


### PR DESCRIPTION
changed `gcc14Stdenv` to `gcc15Stdenv` for nix, to match hyprland

updated nixpkgs in flake.lock for gcc15 to be available