### PR TITLE
formats: fix format selection and some safeguards

### DIFF
--- a/src/image/Image.cpp
+++ b/src/image/Image.cpp
@@ -74,10 +74,18 @@ Hyprgraphics::CImage::CImage(const std::string& path) : filepath(path) {
         if (first_word == "PNG") {
             CAIROSURFACE = PNG::createSurfaceFromPNG(path);
             mime         = "image/png";
-        } else if (first_word == "JPEG") {
+        } else if (first_word == "JPEG" && !type_str.contains("XL") && !type_str.contains("2000") {
             CAIROSURFACE  = JPEG::createSurfaceFromJPEG(path);
             imageHasAlpha = false;
             mime          = "image/jpeg";
+        } else if (first_word == "JPEG" && type_str.contains("XL")) {
+#ifdef JXL_FOUND
+            CAIROSURFACE = JXL::createSurfaceFromJXL(path);
+            mime         = "image/jxl";
+#else
+            lastError = "hyprgraphics compiled without JXL support";
+            return;
+#endif
         } else if (first_word == "BMP") {
             CAIROSURFACE  = BMP::createSurfaceFromBMP(path);
             imageHasAlpha = false;

--- a/src/image/Image.cpp
+++ b/src/image/Image.cpp
@@ -74,7 +74,7 @@ Hyprgraphics::CImage::CImage(const std::string& path) : filepath(path) {
         if (first_word == "PNG") {
             CAIROSURFACE = PNG::createSurfaceFromPNG(path);
             mime         = "image/png";
-        } else if (first_word == "JPEG" && !type_str.contains("XL") && !type_str.contains("2000") {
+        } else if (first_word == "JPEG" && !type_str.contains("XL") && !type_str.contains("2000")) {
             CAIROSURFACE  = JPEG::createSurfaceFromJPEG(path);
             imageHasAlpha = false;
             mime          = "image/jpeg";

--- a/src/image/formats/Jpeg.cpp
+++ b/src/image/formats/Jpeg.cpp
@@ -19,6 +19,9 @@ std::expected<cairo_surface_t*, std::string> JPEG::createSurfaceFromJPEG(const s
     file.seekg(0);
     file.read(reinterpret_cast<char*>(bytes.data()), bytes.size());
 
+    if (bytes[0] != 0xFF || bytes[1] != 0xD8)
+        return std::unexpected("loading jpeg: invalid magic bytes");
+
     // now the JPEG is in the memory
 
     jpeg_decompress_struct decompressStruct = {};

--- a/src/image/formats/Webp.cpp
+++ b/src/image/formats/Webp.cpp
@@ -17,6 +17,9 @@ std::expected<cairo_surface_t*, std::string> WEBP::createSurfaceFromWEBP(const s
     file.seekg(0);
     file.read(reinterpret_cast<char*>(bytes.data()), bytes.size());
 
+    if (bytes[0] != 'R' || bytes[1] != 'I' || bytes[2] != 'F' || bytes[3] != 'F')
+        return std::unexpected("loading webp: invalid magic bytes");
+
     // now the WebP is in the memory
 
     WebPDecoderConfig config;


### PR DESCRIPTION
Closes https://github.com/hyprwm/hyprlock/issues/817

That problem has me pretty worried to be honest.
Using a jxl image as the input for JPEG::createSurfaceFromJPEG shouldn't ever cause memory corruption. (The crashes that happen when a jxl image gets interpreted as a jpeg are not just nullptr derefs)

This is the surface level fix.
However, figuring out where the corruption happens is still a TODO!
Could be that we are not using libjpeg properly or something else donno yet.
