### PR TITLE
replace libspng with libpng in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dep list:
  - libjxl_cms [optional]
  - libjxl_threads [optional]
  - libmagic
- - libspng
+ - libpng
 
 ## Building
 


### PR DESCRIPTION
Update the README.md to follow the change from [v0.1.4](https://github.com/hyprwm/hyprgraphics/releases/tag/v0.1.4).