### PR TITLE
formats: include vector header

### DIFF
--- a/src/image/formats/Avif.cpp
+++ b/src/image/formats/Avif.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <hyprutils/utils/ScopeGuard.hpp>
 #include <libheif/heif.h>
+#include <vector>
 using namespace Hyprutils::Utils;
 
 static std::expected<cairo_surface_t*, std::string> loadFromContext(heif_context* ctx) {


### PR DESCRIPTION
Adds an include to the vector header in Avif.cpp.
Fixes the error `no member named 'vector' in namespace 'std'` on Gentoo Linux amd64 (llvm/musl profile).

<details>

```bash
[5/14] /usr/lib/llvm/22/bin/clang++ -DHEIF_FOUND -DHYPRGRAPHICS_VERSION=\"0.1.5\" -DJXL_FOUND -D__cpp_concepts=202002L -Dhyprgraphics_EXPORTS -I/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/./include -I/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/./src -isystem /usr/include/cairo -isystem /usr/include/freetype2 -isystem /usr/include/harfbuzz -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/pixman-1 -isystem /usr/include/webp -isystem /usr/include/libpng16 -isystem /usr/include/openh264  -O3 -pipe -march=native -g0 -D_FORTIFY_SOURCE=3 -flto -stdlib=libc++ -std=gnu++26 -fPIC -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-missing-braces -O3 -DHWY_SHARED_DEFINE -MD -MT CMakeFiles/hyprgraphics.dir/src/image/formats/Avif.cpp.o -MF CMakeFiles/hyprgraphics.dir/src/image/formats/Avif.cpp.o.d -o CMakeFiles/hyprgraphics.dir/src/image/formats/Avif.cpp.o -c /var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/src/image/formats/Avif.cpp
FAILED: [code=1] CMakeFiles/hyprgraphics.dir/src/image/formats/Avif.cpp.o 
/usr/lib/llvm/22/bin/clang++ -DHEIF_FOUND -DHYPRGRAPHICS_VERSION=\"0.1.5\" -DJXL_FOUND -D__cpp_concepts=202002L -Dhyprgraphics_EXPORTS -I/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/./include -I/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/./src -isystem /usr/include/cairo -isystem /usr/include/freetype2 -isystem /usr/include/harfbuzz -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/pixman-1 -isystem /usr/include/webp -isystem /usr/include/libpng16 -isystem /usr/include/openh264  -O3 -pipe -march=native -g0 -D_FORTIFY_SOURCE=3 -flto -stdlib=libc++ -std=gnu++26 -fPIC -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-missing-braces -O3 -DHWY_SHARED_DEFINE -MD -MT CMakeFiles/hyprgraphics.dir/src/image/formats/Avif.cpp.o -MF CMakeFiles/hyprgraphics.dir/src/image/formats/Avif.cpp.o.d -o CMakeFiles/hyprgraphics.dir/src/image/formats/Avif.cpp.o -c /var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/src/image/formats/Avif.cpp
In file included from <built-in>:528:
<command line>:6:9: warning: redefining builtin macro [-Wbuiltin-macro-redefined]
    6 | #define __cpp_concepts 202002L
      |         ^
/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/src/image/formats/Avif.cpp:33:10: error: no member named 'vector' in namespace 'std'
   33 |     std::vector<uint8_t> rawData;
      |          ^~~~~~
/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/src/image/formats/Avif.cpp:33:17: error: unexpected type name 'uint8_t': expected expression
   33 |     std::vector<uint8_t> rawData;
      |                 ^
/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/src/image/formats/Avif.cpp:33:26: error: use of undeclared identifier 'rawData'
   33 |     std::vector<uint8_t> rawData;
      |                          ^~~~~~~
/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/src/image/formats/Avif.cpp:34:5: error: use of undeclared identifier 'rawData'
   34 |     rawData.resize(width * height * 4);
      |     ^~~~~~~
/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/src/image/formats/Avif.cpp:38:42: error: use of undeclared identifier 'rawData'
   38 |         uint32_t*      dst = (uint32_t*)(rawData.data() + (y * width * 4));
      |                                          ^~~~~~~
/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/src/image/formats/Avif.cpp:57:56: error: use of undeclared identifier 'rawData'
   57 |     memcpy(cairo_image_surface_get_data(CAIROSURFACE), rawData.data(), rawData.size());
      |                                                        ^~~~~~~
/var/tmp/portage/dev-libs/hyprgraphics-9999/work/hyprgraphics-9999/src/image/formats/Avif.cpp:57:72: error: use of undeclared identifier 'rawData'
   57 |     memcpy(cairo_image_surface_get_data(CAIROSURFACE), rawData.data(), rawData.size());
      |                                                                        ^~~~~~~
1 warning and 7 errors generated.
```
</details>