### PR TITLE
Add missing include for `uint8_t`

### DIFF
--- a/src/image/formats/Svg.hpp
+++ b/src/image/formats/Svg.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cairo/cairo.h>
 #include <string>
 #include <expected>


### PR DESCRIPTION
Depending on libc version, might see something like this without the include, since it doesn't know `uint8_t`:

```
In file included from /build/hyprgraphics-0.5.1/src/image/formats/Svg.cpp:1:
/build/hyprgraphics-0.5.1/src/image/formats/Svg.hpp:12:94: error: ISO C++ forbids declaration of 'type name' with no type [-fpermissive]
   12 |     std::expected<cairo_surface_t*, std::string> createSurfaceFromData(const std::span<const uint8_t>&, const Hyprutils::Math::Vector2D& size);
      |                                                                                              ^~~~~~~
/build/hyprgraphics-0.5.1/src/image/formats/Svg.hpp:12:101: error: template argument 1 is invalid
   12 |     std::expected<cairo_surface_t*, std::string> createSurfaceFromData(const std::span<const uint8_t>&, const Hyprutils::Math::Vector2D& size);
```