### PR TITLE
render: add missing `weight` and `italic` to STextResourceData

### DIFF
--- a/include/hyprgraphics/resource/resources/TextResource.hpp
+++ b/include/hyprgraphics/resource/resources/TextResource.hpp
@@ -4,6 +4,7 @@
 #include "../../color/Color.hpp"
 
 #include <cairo/cairo.h>
+#include <pango/pango-font.h>
 
 #include <optional>
 
@@ -29,6 +30,8 @@ namespace Hyprgraphics {
             cairo_hint_style_t                       hintStyle = CAIRO_HINT_STYLE_SLIGHT;
             bool                                     ellipsize = false;
             bool                                     wrap      = true;
+            int                                      weight    = PANGO_WEIGHT_NORMAL;
+            bool                                     italic    = false;
         };
 
         CTextResource(STextResourceData&& data);

--- a/src/resource/resources/TextResource.cpp
+++ b/src/resource/resources/TextResource.cpp
@@ -20,6 +20,8 @@ void CTextResource::render() {
 
     PangoFontDescription* fontDesc = pango_font_description_from_string(m_data.font.c_str());
     pango_font_description_set_size(fontDesc, m_data.fontSize * PANGO_SCALE);
+    pango_font_description_set_weight(fontDesc, static_cast<PangoWeight>(m_data.weight));
+    pango_font_description_set_style(fontDesc, m_data.italic ? PANGO_STYLE_ITALIC : PANGO_STYLE_NORMAL);
     pango_layout_set_font_description(layout, fontDesc);
     pango_font_description_free(fontDesc);
 


### PR DESCRIPTION
Old renderText in Hyprland supports font weight and italic but they're missing in new renderText overload with STextResourceData as its param. This PR add weight and italic support.